### PR TITLE
refactor: 경매 목록 조회 Page 처리

### DIFF
--- a/backend/src/main/java/kr/getz/auction/controller/AuctionController.java
+++ b/backend/src/main/java/kr/getz/auction/controller/AuctionController.java
@@ -2,6 +2,9 @@ package kr.getz.auction.controller;
 
 import java.net.URI;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import kr.getz.auction.dto.request.AuctionWithProductRequest;
 import kr.getz.auction.dto.request.BidRequest;
 import kr.getz.auction.dto.response.AuctionResponse;
-import kr.getz.auction.dto.response.AuctionsResponses;
+import kr.getz.auction.dto.response.AuctionsResponse;
 import kr.getz.auction.service.AuctionService;
 import kr.getz.auth.config.UserPrincipal;
 import kr.getz.user.domain.User;
@@ -38,9 +41,10 @@ public class AuctionController {
 
 	// 경매 조회(목록)
 	@GetMapping
-	public ResponseEntity<AuctionsResponses> getAuctionList(){
-
-		return ResponseEntity.ok(auctionService.getAuctionList());
+	public ResponseEntity<Page<AuctionsResponse>> getAuctionList(
+		@PageableDefault(size = 25, sort = "startTime") Pageable pageable
+	) {
+		return ResponseEntity.ok(auctionService.getAuctionList(pageable));
 	}
 
 	// 경매 조회(상세)
@@ -53,7 +57,7 @@ public class AuctionController {
 	@PostMapping("/{auctionId}/bids")
 	public ResponseEntity<AuctionResponse> placeBid(@UserPrincipal User user,
 		@PathVariable long auctionId,
-		@RequestBody BidRequest request){
+		@RequestBody BidRequest request) {
 
 		return ResponseEntity.ok(auctionService.placeBid(user, request, auctionId));
 	}

--- a/backend/src/main/java/kr/getz/auction/dto/response/AuctionResponse.java
+++ b/backend/src/main/java/kr/getz/auction/dto/response/AuctionResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import kr.getz.auction.domain.Auction;
+import kr.getz.product.domain.ProductImage;
 
 public record AuctionResponse(
 	LocalDateTime startTime,
@@ -13,7 +14,7 @@ public record AuctionResponse(
 	String seller,
 	int startPrice,
 	int currentPrice,
-	int endPrice,
+	int buyNowPrice,
 	List<BidResponse> bidHistory
 ) {
 	public static AuctionResponse from(Auction auction) {
@@ -25,7 +26,7 @@ public record AuctionResponse(
 			auction.getProduct().getUser().getNickname(),
 			auction.getStartPrice(),
 			auction.getCurrentPrice(),
-			auction.getFinalPrice(),
+			auction.getBuyNowPrice(),
 			auction.getBids().stream()
 				.map(BidResponse::from)
 				.toList()

--- a/backend/src/main/java/kr/getz/auction/repository/AuctionRepository.java
+++ b/backend/src/main/java/kr/getz/auction/repository/AuctionRepository.java
@@ -1,8 +1,11 @@
 package kr.getz.auction.repository;
 
+import java.nio.channels.FileChannel;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,4 +21,6 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 	@Query("SELECT a FROM Auction a WHERE a.id = :id")
 	Optional<Auction> findByIdForUpdate(@Param("id") long id);
 
+	@Query("SELECT auction FROM Auction auction JOIN FETCH auction.product product JOIN FETCH product.productImages JOIN FETCH product.user")
+	Page<Auction> findAll(Pageable pageable);
 }

--- a/backend/src/main/java/kr/getz/auction/service/AuctionService.java
+++ b/backend/src/main/java/kr/getz/auction/service/AuctionService.java
@@ -3,6 +3,8 @@ package kr.getz.auction.service;
 import java.util.Comparator;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,15 +45,9 @@ public class AuctionService {
 	}
 
 	@Transactional(readOnly = true)
-	public AuctionsResponses getAuctionList() {
-
-		// TODO : 시작시간이 얼마 남지 않은 순서로 정렬, 추후 필터 정렬로 수정하기
-		List<AuctionsResponse> response = auctionRepository.findAll().stream()
-			.map(AuctionsResponse::from)
-			.sorted(Comparator.comparing(AuctionsResponse::startTime))
-			.toList();
-
-		return new AuctionsResponses(response);
+	public Page<AuctionsResponse> getAuctionList(Pageable pageable) {
+		return auctionRepository.findAll(pageable)
+			.map(AuctionsResponse::from);
 	}
 
 	@Transactional(readOnly = true)

--- a/backend/src/main/java/kr/getz/product/domain/ProductStatus.java
+++ b/backend/src/main/java/kr/getz/product/domain/ProductStatus.java
@@ -3,5 +3,4 @@ package kr.getz.product.domain;
 public enum ProductStatus {
 	AVAILABLE,    // 판매 가능 (새로운 경매 등록 가능)
 	SOLD          // 판매 완료 (새로운 경매 등록 불가)
-
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 경매 목록에 페이지네이션 지원: 기본 페이지 크기 25, 시작 시간 기준 정렬. 대규모 목록에서도 더 빠르고 안정적인 탐색 가능.
- 변경 사항
  - 경매 응답의 가격 필드명이 endPrice에서 buyNowPrice로 변경됨. 클라이언트는 필드 참조 업데이트 필요.
  - 경매 목록 응답이 페이지 기반으로 변경되어 총 페이지, 현재 페이지 등 메타데이터가 포함됨.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->